### PR TITLE
fix travis issue with npm/npm#17413

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,8 @@ before_install:
   - npm --version
   - gcc --version
   - g++ --version
-  - npm install -g ethereumjs-testrpc
-  - npm install -g truffle
+  - npm install -g ethereumjs-testrpc@beta
+  - npm install -g truffle@beta
 
 before_script:
   - testrpc > /dev/null &

--- a/LogoVote/taipei-eth-logovote/package.json
+++ b/LogoVote/taipei-eth-logovote/package.json
@@ -4,8 +4,8 @@
   "description": "Taipei Ethereum LogoVote",
   "license": "GPL-3.0",
   "devDependencies": {
-    "ethereumjs-testrpc": "^3.0.2",
-    "truffle": "^3.2.4"
+    "ethereumjs-testrpc": "^3.9.2",
+    "truffle": "^3.2.93"
   },
   "dependencies": {
     "truffle-hdwallet-provider": "0.0.3"


### PR DESCRIPTION
from https://github.com/npm/npm/issues/17413 , the `bignumber.js` dependency is broken. Fix it with installing beta version of truffle and testrpc